### PR TITLE
event reference onChange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export default class FileInput extends React.Component {
     }
   }
   handleChange = e => {
+    const initialEvent = Object.assign({}, e);
     const files = [];
     for (let i = 0; i < e.target.files.length; i++) {
       // Convert to Array.
@@ -58,7 +59,7 @@ export default class FileInput extends React.Component {
     })))
     .then(zippedResults => {
       // Run the callback after all files have been read.
-      this.props.onChange(e, zippedResults);
+      this.props.onChange(initialEvent, zippedResults);
     });
   }
   triggerInput = e => {


### PR DESCRIPTION
the event was passed trough as a ref which react modifies. it therefore looses its target for example.
the target needs to remain in order to perform operations like resetting the value to upload the same file multiple times.